### PR TITLE
fix conflicts in ply.lex and add extra functionalities to columns names

### DIFF
--- a/app/compiler/lex.py
+++ b/app/compiler/lex.py
@@ -35,7 +35,9 @@ tokens = [
     "PERCENT",
     "LPAREN",
     "RPAREN",
-    "COLNAME",
+    "SIMPLE_COLNAME",
+    "BRACKETED_COLNAME",
+    "COLNUMBER",
     "DATASOURCE",
     "EQUAL",
     "NOTEQUAL",
@@ -47,7 +49,6 @@ tokens = [
     "COMMA",
     "STRING",
     "PATTERN",
-    "COLNUMBER",
 ] + list(reserved.values())
 
 # Regular expression rules for simple tokens
@@ -73,26 +74,140 @@ t_ignore_COMMENT = r"/\*.*\*/"  # Comment
 
 digit = r"([0-9])"
 nondigit = r"([_A-Za-z])"
-identifier = r"(" + nondigit + r"(" + digit + r"|" + nondigit + r")*)"
+# the next pattern not enforce full match
+bracketed_identifier = r"\[([_A-Za-z][ _A-Za-z0-9]*)\]"
+simple_identifier = r"(" + nondigit + r"(" + digit + r"|" + nondigit + r")*)"
+
+
 # the next line is commented to not include [column number]
-# identifier = identifier + r"|" + r"\[" + digit + r"+\]"
+# simple_identifier = simple_identifier + r"|" + r"\[" + digit + r"+\]"
 
 
-@TOKEN(identifier)
-def t_COLNAME(t):
-    t.type = reserved.get(t.value, "COLNAME")  # Check for reserved words
+# region this code to not conflict with SIMPE_COLNAME
+@TOKEN(r"select")
+def t_SELECT(t):
+    return t
+
+
+@TOKEN(r"distinct")
+def t_DISTINCT(t):
+    return t
+
+
+@TOKEN(r"from")
+def t_FROM(t):
+    return t
+
+
+@TOKEN(r"into")
+def t_INTO(t):
+    return t
+
+
+@TOKEN(r"where")
+def t_WHERE(t):
+    return t
+
+
+@TOKEN(r"like")
+def t_LIKE(t):
+    return t
+
+
+@TOKEN(r"not")
+def t_NOT(t):
+    return t
+
+
+@TOKEN(r"and")
+def t_AND(t):
+    return t
+
+
+@TOKEN(r"or")
+def t_OR(t):
+    return t
+
+
+@TOKEN(r"insert")
+def t_INSERT(t):
+    return t
+
+
+@TOKEN(r"values")
+def t_VALUES(t):
+    return t
+
+
+@TOKEN(r"update")
+def t_UPDATE(t):
+    return t
+
+
+@TOKEN(r"set")
+def t_SET(t):
+    return t
+
+
+@TOKEN(r"delete")
+def t_DELETE(t):
+    return t
+
+
+@TOKEN(r"order")
+def t_ORDER(t):
+    return t
+
+
+@TOKEN(r"by")
+def t_BY(t):
+    return t
+
+
+@TOKEN(r"desc")
+def t_DESC(t):
+    return t
+
+
+@TOKEN(r"asc")
+def t_ASC(t):
+    return t
+
+
+@TOKEN(r"limit")
+def t_LIMIT(t):
+    return t
+
+
+@TOKEN(r"tail")
+def t_TAIL(t):
+    return t
+
+
+# endregion
+
+
+@TOKEN(simple_identifier)
+def t_SIMPLE_COLNAME(t):
+    # t.type = reserved.get(t.value, "SIMPLE_COLNAME")  # Check for reserved words
+    return t
+
+
+@TOKEN(bracketed_identifier)
+def t_BRACKETED_COLNAME(t):
+    t.value = t.value[1:-1]
+    return t
+
+
+@TOKEN(r"\[\d+\]")
+def t_COLNUMBER(t):
     return t
 
 
 @TOKEN(r'"([^"\n])*"')
 def t_STRING(t):
     t.value = str(t.value)[1:-1]
-    return t
 
-
-@TOKEN(r"\[\d+\]")
-def t_COLNUMBER(t):
-    t.value = int(t.value[1:-1])
     return t
 
 
@@ -124,7 +239,7 @@ def t_POSITIVE_INTNUMBER(t):
 # endregion
 
 
-@TOKEN(r"\[[^,\]\[]+\]")
+@TOKEN(r"\{[^,{}\[]+\}")
 def t_DATASOURCE(t):
     t.value = str(t.value[1:-1])
     return t

--- a/app/compiler/parser.out
+++ b/app/compiler/parser.out
@@ -34,8 +34,8 @@ Rule 20    conditions -> conditions OR conditions
 Rule 21    conditions -> exp LIKE STRING
 Rule 22    conditions -> exp logical exp
 Rule 23    conditions -> NOT conditions
-Rule 24    exp -> STRING
-Rule 25    exp -> COLNAME
+Rule 24    exp -> column
+Rule 25    exp -> STRING
 Rule 26    exp -> NUMBER
 Rule 27    NUMBER -> NEGATIVE_INTNUMBER
 Rule 28    NUMBER -> POSITIVE_INTNUMBER
@@ -43,76 +43,78 @@ Rule 29    NUMBER -> FLOATNUMBER
 Rule 30    distinct -> DISTINCT
 Rule 31    distinct -> empty
 Rule 32    column -> COLNUMBER
-Rule 33    column -> COLNAME
-Rule 34    columns -> columns COMMA columns
-Rule 35    columns -> column
-Rule 36    select_columns -> TIMES
-Rule 37    select_columns -> columns
-Rule 38    into -> INTO DATASOURCE
-Rule 39    into -> empty
-Rule 40    order -> ORDER BY column way
-Rule 41    order -> empty
-Rule 42    way -> ASC
-Rule 43    way -> empty
-Rule 44    way -> DESC
-Rule 45    limit_or_tail -> LIMIT POSITIVE_INTNUMBER
-Rule 46    limit_or_tail -> TAIL POSITIVE_INTNUMBER
-Rule 47    limit_or_tail -> empty
-Rule 48    value -> STRING
-Rule 49    value -> NUMBER
-Rule 50    values -> values COMMA values
-Rule 51    values -> value
-Rule 52    single_values -> LPAREN values RPAREN
-Rule 53    insert_values -> insert_values COMMA insert_values
-Rule 54    insert_values -> single_values
-Rule 55    icolumn -> LPAREN columns RPAREN
-Rule 56    icolumn -> empty
-Rule 57    assign -> column EQUAL value
-Rule 58    assigns -> assign COMMA assigns
-Rule 59    assigns -> assign
+Rule 33    column -> BRACKETED_COLNAME
+Rule 34    column -> SIMPLE_COLNAME
+Rule 35    columns -> columns COMMA columns
+Rule 36    columns -> column
+Rule 37    select_columns -> TIMES
+Rule 38    select_columns -> columns
+Rule 39    into -> INTO DATASOURCE
+Rule 40    into -> empty
+Rule 41    order -> ORDER BY column way
+Rule 42    order -> empty
+Rule 43    way -> ASC
+Rule 44    way -> empty
+Rule 45    way -> DESC
+Rule 46    limit_or_tail -> LIMIT POSITIVE_INTNUMBER
+Rule 47    limit_or_tail -> TAIL POSITIVE_INTNUMBER
+Rule 48    limit_or_tail -> empty
+Rule 49    value -> STRING
+Rule 50    value -> NUMBER
+Rule 51    values -> values COMMA values
+Rule 52    values -> value
+Rule 53    single_values -> LPAREN values RPAREN
+Rule 54    insert_values -> insert_values COMMA insert_values
+Rule 55    insert_values -> single_values
+Rule 56    icolumn -> LPAREN columns RPAREN
+Rule 57    icolumn -> empty
+Rule 58    assign -> column EQUAL value
+Rule 59    assigns -> assign COMMA assigns
+Rule 60    assigns -> assign
 
 Terminals, with rules where they appear
 
 AND                  : 19
-ASC                  : 42
+ASC                  : 43
 BIGGER               : 13
 BIGGER_EQUAL         : 12
-BY                   : 40
-COLNAME              : 25 33
+BRACKETED_COLNAME    : 33
+BY                   : 41
 COLNUMBER            : 32
-COMMA                : 34 50 53 58
-DATASOURCE           : 6 7 8 9 38
+COMMA                : 35 51 54 59
+DATASOURCE           : 6 7 8 9 39
 DELETE               : 9
-DESC                 : 44
+DESC                 : 45
 DISTINCT             : 30
 DIVIDE               : 
-EQUAL                : 10 57
+EQUAL                : 10 58
 FLOATNUMBER          : 29
 FROM                 : 6 9
 INSERT               : 7
-INTO                 : 7 38
+INTO                 : 7 39
 LIKE                 : 21
-LIMIT                : 45
-LPAREN               : 18 52 55
+LIMIT                : 46
+LPAREN               : 18 53 56
 MINUS                : 
 NEGATIVE_INTNUMBER   : 27
 NOT                  : 23
 NOTEQUAL             : 11
 OR                   : 20
-ORDER                : 40
+ORDER                : 41
 PATTERN              : 
 PERCENT              : 
 PLUS                 : 
-POSITIVE_INTNUMBER   : 28 45 46
-RPAREN               : 18 52 55
+POSITIVE_INTNUMBER   : 28 46 47
+RPAREN               : 18 53 56
 SELECT               : 6
 SET                  : 8
 SIMICOLON            : 6 7 8
+SIMPLE_COLNAME       : 34
 SMALLER              : 15
 SMALLER_EQUAL        : 14
-STRING               : 21 24 48
-TAIL                 : 46
-TIMES                : 36
+STRING               : 21 25 49
+TAIL                 : 47
+TIMES                : 37
 UPDATE               : 8
 VALUES               : 7
 WHERE                : 16
@@ -120,31 +122,31 @@ error                :
 
 Nonterminals, with rules where they appear
 
-NUMBER               : 26 49
-assign               : 58 59
-assigns              : 8 58
-column               : 35 40 57
-columns              : 34 34 37 55
+NUMBER               : 26 50
+assign               : 59 60
+assigns              : 8 59
+column               : 24 36 41 58
+columns              : 35 35 38 56
 conditions           : 16 18 19 19 20 20 23
 delete               : 4
 distinct             : 6
-empty                : 17 31 39 41 43 47 56
+empty                : 17 31 40 42 44 48 57
 exp                  : 21 22 22
 icolumn              : 7
 insert               : 2
-insert_values        : 7 53 53
+insert_values        : 7 54 54
 into                 : 6
 limit_or_tail        : 6
 logical              : 22
 order                : 6
 select               : 1
 select_columns       : 6
-single_values        : 54
+single_values        : 55
 start                : 0
 update               : 3
-value                : 51 57
-values               : 50 50 52
-way                  : 40
+value                : 52 58
+values               : 51 51 53
+way                  : 41
 where                : 6 8 9
 
 Parsing method: LALR
@@ -216,7 +218,8 @@ state 6
     DISTINCT        shift and go to state 11
     TIMES           reduce using rule 5 (empty -> .)
     COLNUMBER       reduce using rule 5 (empty -> .)
-    COLNAME         reduce using rule 5 (empty -> .)
+    BRACKETED_COLNAME reduce using rule 5 (empty -> .)
+    SIMPLE_COLNAME  reduce using rule 5 (empty -> .)
 
     distinct                       shift and go to state 10
     empty                          shift and go to state 12
@@ -245,16 +248,18 @@ state 9
 state 10
 
     (6) select -> SELECT distinct . select_columns FROM DATASOURCE into where order limit_or_tail SIMICOLON
-    (36) select_columns -> . TIMES
-    (37) select_columns -> . columns
-    (34) columns -> . columns COMMA columns
-    (35) columns -> . column
+    (37) select_columns -> . TIMES
+    (38) select_columns -> . columns
+    (35) columns -> . columns COMMA columns
+    (36) columns -> . column
     (32) column -> . COLNUMBER
-    (33) column -> . COLNAME
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
 
     TIMES           shift and go to state 17
     COLNUMBER       shift and go to state 20
-    COLNAME         shift and go to state 21
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
 
     select_columns                 shift and go to state 16
     columns                        shift and go to state 18
@@ -266,7 +271,8 @@ state 11
 
     TIMES           reduce using rule 30 (distinct -> DISTINCT .)
     COLNUMBER       reduce using rule 30 (distinct -> DISTINCT .)
-    COLNAME         reduce using rule 30 (distinct -> DISTINCT .)
+    BRACKETED_COLNAME reduce using rule 30 (distinct -> DISTINCT .)
+    SIMPLE_COLNAME  reduce using rule 30 (distinct -> DISTINCT .)
 
 
 state 12
@@ -275,60 +281,61 @@ state 12
 
     TIMES           reduce using rule 31 (distinct -> empty .)
     COLNUMBER       reduce using rule 31 (distinct -> empty .)
-    COLNAME         reduce using rule 31 (distinct -> empty .)
+    BRACKETED_COLNAME reduce using rule 31 (distinct -> empty .)
+    SIMPLE_COLNAME  reduce using rule 31 (distinct -> empty .)
 
 
 state 13
 
     (7) insert -> INSERT INTO . DATASOURCE icolumn VALUES insert_values SIMICOLON
 
-    DATASOURCE      shift and go to state 22
+    DATASOURCE      shift and go to state 23
 
 
 state 14
 
     (8) update -> UPDATE DATASOURCE . SET assigns where SIMICOLON
 
-    SET             shift and go to state 23
+    SET             shift and go to state 24
 
 
 state 15
 
     (9) delete -> DELETE FROM . DATASOURCE where
 
-    DATASOURCE      shift and go to state 24
+    DATASOURCE      shift and go to state 25
 
 
 state 16
 
     (6) select -> SELECT distinct select_columns . FROM DATASOURCE into where order limit_or_tail SIMICOLON
 
-    FROM            shift and go to state 25
+    FROM            shift and go to state 26
 
 
 state 17
 
-    (36) select_columns -> TIMES .
+    (37) select_columns -> TIMES .
 
-    FROM            reduce using rule 36 (select_columns -> TIMES .)
+    FROM            reduce using rule 37 (select_columns -> TIMES .)
 
 
 state 18
 
-    (37) select_columns -> columns .
-    (34) columns -> columns . COMMA columns
+    (38) select_columns -> columns .
+    (35) columns -> columns . COMMA columns
 
-    FROM            reduce using rule 37 (select_columns -> columns .)
-    COMMA           shift and go to state 26
+    FROM            reduce using rule 38 (select_columns -> columns .)
+    COMMA           shift and go to state 27
 
 
 state 19
 
-    (35) columns -> column .
+    (36) columns -> column .
 
-    COMMA           reduce using rule 35 (columns -> column .)
-    FROM            reduce using rule 35 (columns -> column .)
-    RPAREN          reduce using rule 35 (columns -> column .)
+    COMMA           reduce using rule 36 (columns -> column .)
+    FROM            reduce using rule 36 (columns -> column .)
+    RPAREN          reduce using rule 36 (columns -> column .)
 
 
 state 20
@@ -339,157 +346,208 @@ state 20
     FROM            reduce using rule 32 (column -> COLNUMBER .)
     EQUAL           reduce using rule 32 (column -> COLNUMBER .)
     RPAREN          reduce using rule 32 (column -> COLNUMBER .)
-    ASC             reduce using rule 32 (column -> COLNUMBER .)
-    DESC            reduce using rule 32 (column -> COLNUMBER .)
+    LIKE            reduce using rule 32 (column -> COLNUMBER .)
+    NOTEQUAL        reduce using rule 32 (column -> COLNUMBER .)
+    BIGGER_EQUAL    reduce using rule 32 (column -> COLNUMBER .)
+    BIGGER          reduce using rule 32 (column -> COLNUMBER .)
+    SMALLER_EQUAL   reduce using rule 32 (column -> COLNUMBER .)
+    SMALLER         reduce using rule 32 (column -> COLNUMBER .)
+    AND             reduce using rule 32 (column -> COLNUMBER .)
+    OR              reduce using rule 32 (column -> COLNUMBER .)
+    $end            reduce using rule 32 (column -> COLNUMBER .)
+    SIMICOLON       reduce using rule 32 (column -> COLNUMBER .)
+    ORDER           reduce using rule 32 (column -> COLNUMBER .)
     LIMIT           reduce using rule 32 (column -> COLNUMBER .)
     TAIL            reduce using rule 32 (column -> COLNUMBER .)
-    SIMICOLON       reduce using rule 32 (column -> COLNUMBER .)
+    ASC             reduce using rule 32 (column -> COLNUMBER .)
+    DESC            reduce using rule 32 (column -> COLNUMBER .)
 
 
 state 21
 
-    (33) column -> COLNAME .
+    (33) column -> BRACKETED_COLNAME .
 
-    COMMA           reduce using rule 33 (column -> COLNAME .)
-    FROM            reduce using rule 33 (column -> COLNAME .)
-    EQUAL           reduce using rule 33 (column -> COLNAME .)
-    RPAREN          reduce using rule 33 (column -> COLNAME .)
-    ASC             reduce using rule 33 (column -> COLNAME .)
-    DESC            reduce using rule 33 (column -> COLNAME .)
-    LIMIT           reduce using rule 33 (column -> COLNAME .)
-    TAIL            reduce using rule 33 (column -> COLNAME .)
-    SIMICOLON       reduce using rule 33 (column -> COLNAME .)
+    COMMA           reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    FROM            reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    EQUAL           reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    RPAREN          reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    LIKE            reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    NOTEQUAL        reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    BIGGER_EQUAL    reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    BIGGER          reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    SMALLER_EQUAL   reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    SMALLER         reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    AND             reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    OR              reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    $end            reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    SIMICOLON       reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    ORDER           reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    LIMIT           reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    TAIL            reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    ASC             reduce using rule 33 (column -> BRACKETED_COLNAME .)
+    DESC            reduce using rule 33 (column -> BRACKETED_COLNAME .)
 
 
 state 22
 
-    (7) insert -> INSERT INTO DATASOURCE . icolumn VALUES insert_values SIMICOLON
-    (55) icolumn -> . LPAREN columns RPAREN
-    (56) icolumn -> . empty
-    (5) empty -> .
+    (34) column -> SIMPLE_COLNAME .
 
-    LPAREN          shift and go to state 28
-    VALUES          reduce using rule 5 (empty -> .)
+    COMMA           reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    FROM            reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    EQUAL           reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    RPAREN          reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    LIKE            reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    NOTEQUAL        reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    BIGGER_EQUAL    reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    BIGGER          reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    SMALLER_EQUAL   reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    SMALLER         reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    AND             reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    OR              reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    $end            reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    SIMICOLON       reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    ORDER           reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    LIMIT           reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    TAIL            reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    ASC             reduce using rule 34 (column -> SIMPLE_COLNAME .)
+    DESC            reduce using rule 34 (column -> SIMPLE_COLNAME .)
 
-    icolumn                        shift and go to state 27
-    empty                          shift and go to state 29
 
 state 23
 
-    (8) update -> UPDATE DATASOURCE SET . assigns where SIMICOLON
-    (58) assigns -> . assign COMMA assigns
-    (59) assigns -> . assign
-    (57) assign -> . column EQUAL value
-    (32) column -> . COLNUMBER
-    (33) column -> . COLNAME
+    (7) insert -> INSERT INTO DATASOURCE . icolumn VALUES insert_values SIMICOLON
+    (56) icolumn -> . LPAREN columns RPAREN
+    (57) icolumn -> . empty
+    (5) empty -> .
 
-    COLNUMBER       shift and go to state 20
-    COLNAME         shift and go to state 21
+    LPAREN          shift and go to state 29
+    VALUES          reduce using rule 5 (empty -> .)
 
-    assigns                        shift and go to state 30
-    assign                         shift and go to state 31
-    column                         shift and go to state 32
+    icolumn                        shift and go to state 28
+    empty                          shift and go to state 30
 
 state 24
+
+    (8) update -> UPDATE DATASOURCE SET . assigns where SIMICOLON
+    (59) assigns -> . assign COMMA assigns
+    (60) assigns -> . assign
+    (58) assign -> . column EQUAL value
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
+
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+
+    assigns                        shift and go to state 31
+    assign                         shift and go to state 32
+    column                         shift and go to state 33
+
+state 25
 
     (9) delete -> DELETE FROM DATASOURCE . where
     (16) where -> . WHERE conditions
     (17) where -> . empty
     (5) empty -> .
 
-    WHERE           shift and go to state 34
+    WHERE           shift and go to state 35
     $end            reduce using rule 5 (empty -> .)
 
-    where                          shift and go to state 33
-    empty                          shift and go to state 35
-
-state 25
-
-    (6) select -> SELECT distinct select_columns FROM . DATASOURCE into where order limit_or_tail SIMICOLON
-
-    DATASOURCE      shift and go to state 36
-
+    where                          shift and go to state 34
+    empty                          shift and go to state 36
 
 state 26
 
-    (34) columns -> columns COMMA . columns
-    (34) columns -> . columns COMMA columns
-    (35) columns -> . column
-    (32) column -> . COLNUMBER
-    (33) column -> . COLNAME
+    (6) select -> SELECT distinct select_columns FROM . DATASOURCE into where order limit_or_tail SIMICOLON
 
-    COLNUMBER       shift and go to state 20
-    COLNAME         shift and go to state 21
+    DATASOURCE      shift and go to state 37
 
-    columns                        shift and go to state 37
-    column                         shift and go to state 19
 
 state 27
 
-    (7) insert -> INSERT INTO DATASOURCE icolumn . VALUES insert_values SIMICOLON
+    (35) columns -> columns COMMA . columns
+    (35) columns -> . columns COMMA columns
+    (36) columns -> . column
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
 
-    VALUES          shift and go to state 38
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
 
+    columns                        shift and go to state 38
+    column                         shift and go to state 19
 
 state 28
 
-    (55) icolumn -> LPAREN . columns RPAREN
-    (34) columns -> . columns COMMA columns
-    (35) columns -> . column
-    (32) column -> . COLNUMBER
-    (33) column -> . COLNAME
+    (7) insert -> INSERT INTO DATASOURCE icolumn . VALUES insert_values SIMICOLON
 
-    COLNUMBER       shift and go to state 20
-    COLNAME         shift and go to state 21
+    VALUES          shift and go to state 39
 
-    columns                        shift and go to state 39
-    column                         shift and go to state 19
 
 state 29
 
-    (56) icolumn -> empty .
+    (56) icolumn -> LPAREN . columns RPAREN
+    (35) columns -> . columns COMMA columns
+    (36) columns -> . column
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
 
-    VALUES          reduce using rule 56 (icolumn -> empty .)
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
 
+    columns                        shift and go to state 40
+    column                         shift and go to state 19
 
 state 30
+
+    (57) icolumn -> empty .
+
+    VALUES          reduce using rule 57 (icolumn -> empty .)
+
+
+state 31
 
     (8) update -> UPDATE DATASOURCE SET assigns . where SIMICOLON
     (16) where -> . WHERE conditions
     (17) where -> . empty
     (5) empty -> .
 
-    WHERE           shift and go to state 34
+    WHERE           shift and go to state 35
     SIMICOLON       reduce using rule 5 (empty -> .)
 
-    where                          shift and go to state 40
-    empty                          shift and go to state 35
-
-state 31
-
-    (58) assigns -> assign . COMMA assigns
-    (59) assigns -> assign .
-
-    COMMA           shift and go to state 41
-    WHERE           reduce using rule 59 (assigns -> assign .)
-    SIMICOLON       reduce using rule 59 (assigns -> assign .)
-
+    where                          shift and go to state 41
+    empty                          shift and go to state 36
 
 state 32
 
-    (57) assign -> column . EQUAL value
+    (59) assigns -> assign . COMMA assigns
+    (60) assigns -> assign .
 
-    EQUAL           shift and go to state 42
+    COMMA           shift and go to state 42
+    WHERE           reduce using rule 60 (assigns -> assign .)
+    SIMICOLON       reduce using rule 60 (assigns -> assign .)
 
 
 state 33
+
+    (58) assign -> column . EQUAL value
+
+    EQUAL           shift and go to state 43
+
+
+state 34
 
     (9) delete -> DELETE FROM DATASOURCE where .
 
     $end            reduce using rule 9 (delete -> DELETE FROM DATASOURCE where .)
 
 
-state 34
+state 35
 
     (16) where -> WHERE . conditions
     (18) conditions -> . LPAREN conditions RPAREN
@@ -498,26 +556,32 @@ state 34
     (21) conditions -> . exp LIKE STRING
     (22) conditions -> . exp logical exp
     (23) conditions -> . NOT conditions
-    (24) exp -> . STRING
-    (25) exp -> . COLNAME
+    (24) exp -> . column
+    (25) exp -> . STRING
     (26) exp -> . NUMBER
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    LPAREN          shift and go to state 44
-    NOT             shift and go to state 47
-    STRING          shift and go to state 46
-    COLNAME         shift and go to state 48
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    LPAREN          shift and go to state 45
+    NOT             shift and go to state 48
+    STRING          shift and go to state 47
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    conditions                     shift and go to state 43
-    exp                            shift and go to state 45
-    NUMBER                         shift and go to state 49
+    conditions                     shift and go to state 44
+    exp                            shift and go to state 46
+    column                         shift and go to state 49
+    NUMBER                         shift and go to state 50
 
-state 35
+state 36
 
     (17) where -> empty .
 
@@ -528,98 +592,100 @@ state 35
     TAIL            reduce using rule 17 (where -> empty .)
 
 
-state 36
+state 37
 
     (6) select -> SELECT distinct select_columns FROM DATASOURCE . into where order limit_or_tail SIMICOLON
-    (38) into -> . INTO DATASOURCE
-    (39) into -> . empty
+    (39) into -> . INTO DATASOURCE
+    (40) into -> . empty
     (5) empty -> .
 
-    INTO            shift and go to state 54
+    INTO            shift and go to state 55
     WHERE           reduce using rule 5 (empty -> .)
     ORDER           reduce using rule 5 (empty -> .)
     LIMIT           reduce using rule 5 (empty -> .)
     TAIL            reduce using rule 5 (empty -> .)
     SIMICOLON       reduce using rule 5 (empty -> .)
 
-    into                           shift and go to state 53
-    empty                          shift and go to state 55
-
-state 37
-
-    (34) columns -> columns COMMA columns .
-    (34) columns -> columns . COMMA columns
-
-  ! shift/reduce conflict for COMMA resolved as shift
-    FROM            reduce using rule 34 (columns -> columns COMMA columns .)
-    RPAREN          reduce using rule 34 (columns -> columns COMMA columns .)
-    COMMA           shift and go to state 26
-
-  ! COMMA           [ reduce using rule 34 (columns -> columns COMMA columns .) ]
-
+    into                           shift and go to state 54
+    empty                          shift and go to state 56
 
 state 38
 
-    (7) insert -> INSERT INTO DATASOURCE icolumn VALUES . insert_values SIMICOLON
-    (53) insert_values -> . insert_values COMMA insert_values
-    (54) insert_values -> . single_values
-    (52) single_values -> . LPAREN values RPAREN
+    (35) columns -> columns COMMA columns .
+    (35) columns -> columns . COMMA columns
 
-    LPAREN          shift and go to state 58
+  ! shift/reduce conflict for COMMA resolved as shift
+    FROM            reduce using rule 35 (columns -> columns COMMA columns .)
+    RPAREN          reduce using rule 35 (columns -> columns COMMA columns .)
+    COMMA           shift and go to state 27
 
-    insert_values                  shift and go to state 56
-    single_values                  shift and go to state 57
+  ! COMMA           [ reduce using rule 35 (columns -> columns COMMA columns .) ]
+
 
 state 39
 
-    (55) icolumn -> LPAREN columns . RPAREN
-    (34) columns -> columns . COMMA columns
+    (7) insert -> INSERT INTO DATASOURCE icolumn VALUES . insert_values SIMICOLON
+    (54) insert_values -> . insert_values COMMA insert_values
+    (55) insert_values -> . single_values
+    (53) single_values -> . LPAREN values RPAREN
 
-    RPAREN          shift and go to state 59
-    COMMA           shift and go to state 26
+    LPAREN          shift and go to state 59
 
+    insert_values                  shift and go to state 57
+    single_values                  shift and go to state 58
 
 state 40
 
-    (8) update -> UPDATE DATASOURCE SET assigns where . SIMICOLON
+    (56) icolumn -> LPAREN columns . RPAREN
+    (35) columns -> columns . COMMA columns
 
-    SIMICOLON       shift and go to state 60
+    RPAREN          shift and go to state 60
+    COMMA           shift and go to state 27
 
 
 state 41
 
-    (58) assigns -> assign COMMA . assigns
-    (58) assigns -> . assign COMMA assigns
-    (59) assigns -> . assign
-    (57) assign -> . column EQUAL value
-    (32) column -> . COLNUMBER
-    (33) column -> . COLNAME
+    (8) update -> UPDATE DATASOURCE SET assigns where . SIMICOLON
 
-    COLNUMBER       shift and go to state 20
-    COLNAME         shift and go to state 21
+    SIMICOLON       shift and go to state 61
 
-    assign                         shift and go to state 31
-    assigns                        shift and go to state 61
-    column                         shift and go to state 32
 
 state 42
 
-    (57) assign -> column EQUAL . value
-    (48) value -> . STRING
-    (49) value -> . NUMBER
+    (59) assigns -> assign COMMA . assigns
+    (59) assigns -> . assign COMMA assigns
+    (60) assigns -> . assign
+    (58) assign -> . column EQUAL value
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
+
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+
+    assign                         shift and go to state 32
+    assigns                        shift and go to state 62
+    column                         shift and go to state 33
+
+state 43
+
+    (58) assign -> column EQUAL . value
+    (49) value -> . STRING
+    (50) value -> . NUMBER
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    STRING          shift and go to state 63
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    STRING          shift and go to state 64
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    value                          shift and go to state 62
-    NUMBER                         shift and go to state 64
+    value                          shift and go to state 63
+    NUMBER                         shift and go to state 65
 
-state 43
+state 44
 
     (16) where -> WHERE conditions .
     (19) conditions -> conditions . AND conditions
@@ -630,11 +696,11 @@ state 43
     ORDER           reduce using rule 16 (where -> WHERE conditions .)
     LIMIT           reduce using rule 16 (where -> WHERE conditions .)
     TAIL            reduce using rule 16 (where -> WHERE conditions .)
-    AND             shift and go to state 65
-    OR              shift and go to state 66
+    AND             shift and go to state 66
+    OR              shift and go to state 67
 
 
-state 44
+state 45
 
     (18) conditions -> LPAREN . conditions RPAREN
     (18) conditions -> . LPAREN conditions RPAREN
@@ -643,26 +709,32 @@ state 44
     (21) conditions -> . exp LIKE STRING
     (22) conditions -> . exp logical exp
     (23) conditions -> . NOT conditions
-    (24) exp -> . STRING
-    (25) exp -> . COLNAME
+    (24) exp -> . column
+    (25) exp -> . STRING
     (26) exp -> . NUMBER
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    LPAREN          shift and go to state 44
-    NOT             shift and go to state 47
-    STRING          shift and go to state 46
-    COLNAME         shift and go to state 48
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    LPAREN          shift and go to state 45
+    NOT             shift and go to state 48
+    STRING          shift and go to state 47
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    conditions                     shift and go to state 67
-    exp                            shift and go to state 45
-    NUMBER                         shift and go to state 49
+    conditions                     shift and go to state 68
+    exp                            shift and go to state 46
+    column                         shift and go to state 49
+    NUMBER                         shift and go to state 50
 
-state 45
+state 46
 
     (21) conditions -> exp . LIKE STRING
     (22) conditions -> exp . logical exp
@@ -673,38 +745,38 @@ state 45
     (14) logical -> . SMALLER_EQUAL
     (15) logical -> . SMALLER
 
-    LIKE            shift and go to state 68
-    EQUAL           shift and go to state 70
-    NOTEQUAL        shift and go to state 71
-    BIGGER_EQUAL    shift and go to state 72
-    BIGGER          shift and go to state 73
-    SMALLER_EQUAL   shift and go to state 74
-    SMALLER         shift and go to state 75
+    LIKE            shift and go to state 69
+    EQUAL           shift and go to state 71
+    NOTEQUAL        shift and go to state 72
+    BIGGER_EQUAL    shift and go to state 73
+    BIGGER          shift and go to state 74
+    SMALLER_EQUAL   shift and go to state 75
+    SMALLER         shift and go to state 76
 
-    logical                        shift and go to state 69
-
-state 46
-
-    (24) exp -> STRING .
-
-    LIKE            reduce using rule 24 (exp -> STRING .)
-    EQUAL           reduce using rule 24 (exp -> STRING .)
-    NOTEQUAL        reduce using rule 24 (exp -> STRING .)
-    BIGGER_EQUAL    reduce using rule 24 (exp -> STRING .)
-    BIGGER          reduce using rule 24 (exp -> STRING .)
-    SMALLER_EQUAL   reduce using rule 24 (exp -> STRING .)
-    SMALLER         reduce using rule 24 (exp -> STRING .)
-    AND             reduce using rule 24 (exp -> STRING .)
-    OR              reduce using rule 24 (exp -> STRING .)
-    $end            reduce using rule 24 (exp -> STRING .)
-    SIMICOLON       reduce using rule 24 (exp -> STRING .)
-    ORDER           reduce using rule 24 (exp -> STRING .)
-    LIMIT           reduce using rule 24 (exp -> STRING .)
-    TAIL            reduce using rule 24 (exp -> STRING .)
-    RPAREN          reduce using rule 24 (exp -> STRING .)
-
+    logical                        shift and go to state 70
 
 state 47
+
+    (25) exp -> STRING .
+
+    LIKE            reduce using rule 25 (exp -> STRING .)
+    EQUAL           reduce using rule 25 (exp -> STRING .)
+    NOTEQUAL        reduce using rule 25 (exp -> STRING .)
+    BIGGER_EQUAL    reduce using rule 25 (exp -> STRING .)
+    BIGGER          reduce using rule 25 (exp -> STRING .)
+    SMALLER_EQUAL   reduce using rule 25 (exp -> STRING .)
+    SMALLER         reduce using rule 25 (exp -> STRING .)
+    AND             reduce using rule 25 (exp -> STRING .)
+    OR              reduce using rule 25 (exp -> STRING .)
+    $end            reduce using rule 25 (exp -> STRING .)
+    SIMICOLON       reduce using rule 25 (exp -> STRING .)
+    ORDER           reduce using rule 25 (exp -> STRING .)
+    LIMIT           reduce using rule 25 (exp -> STRING .)
+    TAIL            reduce using rule 25 (exp -> STRING .)
+    RPAREN          reduce using rule 25 (exp -> STRING .)
+
+
+state 48
 
     (23) conditions -> NOT . conditions
     (18) conditions -> . LPAREN conditions RPAREN
@@ -713,47 +785,53 @@ state 47
     (21) conditions -> . exp LIKE STRING
     (22) conditions -> . exp logical exp
     (23) conditions -> . NOT conditions
-    (24) exp -> . STRING
-    (25) exp -> . COLNAME
+    (24) exp -> . column
+    (25) exp -> . STRING
     (26) exp -> . NUMBER
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    LPAREN          shift and go to state 44
-    NOT             shift and go to state 47
-    STRING          shift and go to state 46
-    COLNAME         shift and go to state 48
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    LPAREN          shift and go to state 45
+    NOT             shift and go to state 48
+    STRING          shift and go to state 47
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    conditions                     shift and go to state 76
-    exp                            shift and go to state 45
-    NUMBER                         shift and go to state 49
-
-state 48
-
-    (25) exp -> COLNAME .
-
-    LIKE            reduce using rule 25 (exp -> COLNAME .)
-    EQUAL           reduce using rule 25 (exp -> COLNAME .)
-    NOTEQUAL        reduce using rule 25 (exp -> COLNAME .)
-    BIGGER_EQUAL    reduce using rule 25 (exp -> COLNAME .)
-    BIGGER          reduce using rule 25 (exp -> COLNAME .)
-    SMALLER_EQUAL   reduce using rule 25 (exp -> COLNAME .)
-    SMALLER         reduce using rule 25 (exp -> COLNAME .)
-    AND             reduce using rule 25 (exp -> COLNAME .)
-    OR              reduce using rule 25 (exp -> COLNAME .)
-    $end            reduce using rule 25 (exp -> COLNAME .)
-    SIMICOLON       reduce using rule 25 (exp -> COLNAME .)
-    ORDER           reduce using rule 25 (exp -> COLNAME .)
-    LIMIT           reduce using rule 25 (exp -> COLNAME .)
-    TAIL            reduce using rule 25 (exp -> COLNAME .)
-    RPAREN          reduce using rule 25 (exp -> COLNAME .)
-
+    conditions                     shift and go to state 77
+    exp                            shift and go to state 46
+    column                         shift and go to state 49
+    NUMBER                         shift and go to state 50
 
 state 49
+
+    (24) exp -> column .
+
+    LIKE            reduce using rule 24 (exp -> column .)
+    EQUAL           reduce using rule 24 (exp -> column .)
+    NOTEQUAL        reduce using rule 24 (exp -> column .)
+    BIGGER_EQUAL    reduce using rule 24 (exp -> column .)
+    BIGGER          reduce using rule 24 (exp -> column .)
+    SMALLER_EQUAL   reduce using rule 24 (exp -> column .)
+    SMALLER         reduce using rule 24 (exp -> column .)
+    AND             reduce using rule 24 (exp -> column .)
+    OR              reduce using rule 24 (exp -> column .)
+    $end            reduce using rule 24 (exp -> column .)
+    SIMICOLON       reduce using rule 24 (exp -> column .)
+    ORDER           reduce using rule 24 (exp -> column .)
+    LIMIT           reduce using rule 24 (exp -> column .)
+    TAIL            reduce using rule 24 (exp -> column .)
+    RPAREN          reduce using rule 24 (exp -> column .)
+
+
+state 50
 
     (26) exp -> NUMBER .
 
@@ -774,7 +852,7 @@ state 49
     RPAREN          reduce using rule 26 (exp -> NUMBER .)
 
 
-state 50
+state 51
 
     (27) NUMBER -> NEGATIVE_INTNUMBER .
 
@@ -797,7 +875,7 @@ state 50
     TAIL            reduce using rule 27 (NUMBER -> NEGATIVE_INTNUMBER .)
 
 
-state 51
+state 52
 
     (28) NUMBER -> POSITIVE_INTNUMBER .
 
@@ -820,7 +898,7 @@ state 51
     TAIL            reduce using rule 28 (NUMBER -> POSITIVE_INTNUMBER .)
 
 
-state 52
+state 53
 
     (29) NUMBER -> FLOATNUMBER .
 
@@ -843,129 +921,129 @@ state 52
     TAIL            reduce using rule 29 (NUMBER -> FLOATNUMBER .)
 
 
-state 53
+state 54
 
     (6) select -> SELECT distinct select_columns FROM DATASOURCE into . where order limit_or_tail SIMICOLON
     (16) where -> . WHERE conditions
     (17) where -> . empty
     (5) empty -> .
 
-    WHERE           shift and go to state 34
+    WHERE           shift and go to state 35
     ORDER           reduce using rule 5 (empty -> .)
     LIMIT           reduce using rule 5 (empty -> .)
     TAIL            reduce using rule 5 (empty -> .)
     SIMICOLON       reduce using rule 5 (empty -> .)
 
-    where                          shift and go to state 77
-    empty                          shift and go to state 35
-
-state 54
-
-    (38) into -> INTO . DATASOURCE
-
-    DATASOURCE      shift and go to state 78
-
+    where                          shift and go to state 78
+    empty                          shift and go to state 36
 
 state 55
 
-    (39) into -> empty .
+    (39) into -> INTO . DATASOURCE
 
-    WHERE           reduce using rule 39 (into -> empty .)
-    ORDER           reduce using rule 39 (into -> empty .)
-    LIMIT           reduce using rule 39 (into -> empty .)
-    TAIL            reduce using rule 39 (into -> empty .)
-    SIMICOLON       reduce using rule 39 (into -> empty .)
+    DATASOURCE      shift and go to state 79
 
 
 state 56
 
-    (7) insert -> INSERT INTO DATASOURCE icolumn VALUES insert_values . SIMICOLON
-    (53) insert_values -> insert_values . COMMA insert_values
+    (40) into -> empty .
 
-    SIMICOLON       shift and go to state 79
-    COMMA           shift and go to state 80
+    WHERE           reduce using rule 40 (into -> empty .)
+    ORDER           reduce using rule 40 (into -> empty .)
+    LIMIT           reduce using rule 40 (into -> empty .)
+    TAIL            reduce using rule 40 (into -> empty .)
+    SIMICOLON       reduce using rule 40 (into -> empty .)
 
 
 state 57
 
-    (54) insert_values -> single_values .
+    (7) insert -> INSERT INTO DATASOURCE icolumn VALUES insert_values . SIMICOLON
+    (54) insert_values -> insert_values . COMMA insert_values
 
-    SIMICOLON       reduce using rule 54 (insert_values -> single_values .)
-    COMMA           reduce using rule 54 (insert_values -> single_values .)
+    SIMICOLON       shift and go to state 80
+    COMMA           shift and go to state 81
 
 
 state 58
 
-    (52) single_values -> LPAREN . values RPAREN
-    (50) values -> . values COMMA values
-    (51) values -> . value
-    (48) value -> . STRING
-    (49) value -> . NUMBER
+    (55) insert_values -> single_values .
+
+    SIMICOLON       reduce using rule 55 (insert_values -> single_values .)
+    COMMA           reduce using rule 55 (insert_values -> single_values .)
+
+
+state 59
+
+    (53) single_values -> LPAREN . values RPAREN
+    (51) values -> . values COMMA values
+    (52) values -> . value
+    (49) value -> . STRING
+    (50) value -> . NUMBER
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    STRING          shift and go to state 63
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    STRING          shift and go to state 64
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    values                         shift and go to state 81
-    value                          shift and go to state 82
-    NUMBER                         shift and go to state 64
-
-state 59
-
-    (55) icolumn -> LPAREN columns RPAREN .
-
-    VALUES          reduce using rule 55 (icolumn -> LPAREN columns RPAREN .)
-
+    values                         shift and go to state 82
+    value                          shift and go to state 83
+    NUMBER                         shift and go to state 65
 
 state 60
+
+    (56) icolumn -> LPAREN columns RPAREN .
+
+    VALUES          reduce using rule 56 (icolumn -> LPAREN columns RPAREN .)
+
+
+state 61
 
     (8) update -> UPDATE DATASOURCE SET assigns where SIMICOLON .
 
     $end            reduce using rule 8 (update -> UPDATE DATASOURCE SET assigns where SIMICOLON .)
 
 
-state 61
-
-    (58) assigns -> assign COMMA assigns .
-
-    WHERE           reduce using rule 58 (assigns -> assign COMMA assigns .)
-    SIMICOLON       reduce using rule 58 (assigns -> assign COMMA assigns .)
-
-
 state 62
 
-    (57) assign -> column EQUAL value .
+    (59) assigns -> assign COMMA assigns .
 
-    COMMA           reduce using rule 57 (assign -> column EQUAL value .)
-    WHERE           reduce using rule 57 (assign -> column EQUAL value .)
-    SIMICOLON       reduce using rule 57 (assign -> column EQUAL value .)
+    WHERE           reduce using rule 59 (assigns -> assign COMMA assigns .)
+    SIMICOLON       reduce using rule 59 (assigns -> assign COMMA assigns .)
 
 
 state 63
 
-    (48) value -> STRING .
+    (58) assign -> column EQUAL value .
 
-    COMMA           reduce using rule 48 (value -> STRING .)
-    WHERE           reduce using rule 48 (value -> STRING .)
-    SIMICOLON       reduce using rule 48 (value -> STRING .)
-    RPAREN          reduce using rule 48 (value -> STRING .)
+    COMMA           reduce using rule 58 (assign -> column EQUAL value .)
+    WHERE           reduce using rule 58 (assign -> column EQUAL value .)
+    SIMICOLON       reduce using rule 58 (assign -> column EQUAL value .)
 
 
 state 64
 
-    (49) value -> NUMBER .
+    (49) value -> STRING .
 
-    COMMA           reduce using rule 49 (value -> NUMBER .)
-    WHERE           reduce using rule 49 (value -> NUMBER .)
-    SIMICOLON       reduce using rule 49 (value -> NUMBER .)
-    RPAREN          reduce using rule 49 (value -> NUMBER .)
+    COMMA           reduce using rule 49 (value -> STRING .)
+    WHERE           reduce using rule 49 (value -> STRING .)
+    SIMICOLON       reduce using rule 49 (value -> STRING .)
+    RPAREN          reduce using rule 49 (value -> STRING .)
 
 
 state 65
+
+    (50) value -> NUMBER .
+
+    COMMA           reduce using rule 50 (value -> NUMBER .)
+    WHERE           reduce using rule 50 (value -> NUMBER .)
+    SIMICOLON       reduce using rule 50 (value -> NUMBER .)
+    RPAREN          reduce using rule 50 (value -> NUMBER .)
+
+
+state 66
 
     (19) conditions -> conditions AND . conditions
     (18) conditions -> . LPAREN conditions RPAREN
@@ -974,26 +1052,32 @@ state 65
     (21) conditions -> . exp LIKE STRING
     (22) conditions -> . exp logical exp
     (23) conditions -> . NOT conditions
-    (24) exp -> . STRING
-    (25) exp -> . COLNAME
+    (24) exp -> . column
+    (25) exp -> . STRING
     (26) exp -> . NUMBER
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    LPAREN          shift and go to state 44
-    NOT             shift and go to state 47
-    STRING          shift and go to state 46
-    COLNAME         shift and go to state 48
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    LPAREN          shift and go to state 45
+    NOT             shift and go to state 48
+    STRING          shift and go to state 47
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    conditions                     shift and go to state 83
-    exp                            shift and go to state 45
-    NUMBER                         shift and go to state 49
+    conditions                     shift and go to state 84
+    exp                            shift and go to state 46
+    column                         shift and go to state 49
+    NUMBER                         shift and go to state 50
 
-state 66
+state 67
 
     (20) conditions -> conditions OR . conditions
     (18) conditions -> . LPAREN conditions RPAREN
@@ -1002,129 +1086,153 @@ state 66
     (21) conditions -> . exp LIKE STRING
     (22) conditions -> . exp logical exp
     (23) conditions -> . NOT conditions
-    (24) exp -> . STRING
-    (25) exp -> . COLNAME
+    (24) exp -> . column
+    (25) exp -> . STRING
     (26) exp -> . NUMBER
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    LPAREN          shift and go to state 44
-    NOT             shift and go to state 47
-    STRING          shift and go to state 46
-    COLNAME         shift and go to state 48
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    LPAREN          shift and go to state 45
+    NOT             shift and go to state 48
+    STRING          shift and go to state 47
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    conditions                     shift and go to state 84
-    exp                            shift and go to state 45
-    NUMBER                         shift and go to state 49
+    conditions                     shift and go to state 85
+    exp                            shift and go to state 46
+    column                         shift and go to state 49
+    NUMBER                         shift and go to state 50
 
-state 67
+state 68
 
     (18) conditions -> LPAREN conditions . RPAREN
     (19) conditions -> conditions . AND conditions
     (20) conditions -> conditions . OR conditions
 
-    RPAREN          shift and go to state 85
-    AND             shift and go to state 65
-    OR              shift and go to state 66
-
-
-state 68
-
-    (21) conditions -> exp LIKE . STRING
-
-    STRING          shift and go to state 86
+    RPAREN          shift and go to state 86
+    AND             shift and go to state 66
+    OR              shift and go to state 67
 
 
 state 69
 
+    (21) conditions -> exp LIKE . STRING
+
+    STRING          shift and go to state 87
+
+
+state 70
+
     (22) conditions -> exp logical . exp
-    (24) exp -> . STRING
-    (25) exp -> . COLNAME
+    (24) exp -> . column
+    (25) exp -> . STRING
     (26) exp -> . NUMBER
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    STRING          shift and go to state 46
-    COLNAME         shift and go to state 48
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    STRING          shift and go to state 47
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    exp                            shift and go to state 87
-    NUMBER                         shift and go to state 49
+    exp                            shift and go to state 88
+    column                         shift and go to state 49
+    NUMBER                         shift and go to state 50
 
-state 70
+state 71
 
     (10) logical -> EQUAL .
 
     STRING          reduce using rule 10 (logical -> EQUAL .)
-    COLNAME         reduce using rule 10 (logical -> EQUAL .)
+    COLNUMBER       reduce using rule 10 (logical -> EQUAL .)
+    BRACKETED_COLNAME reduce using rule 10 (logical -> EQUAL .)
+    SIMPLE_COLNAME  reduce using rule 10 (logical -> EQUAL .)
     NEGATIVE_INTNUMBER reduce using rule 10 (logical -> EQUAL .)
     POSITIVE_INTNUMBER reduce using rule 10 (logical -> EQUAL .)
     FLOATNUMBER     reduce using rule 10 (logical -> EQUAL .)
 
 
-state 71
+state 72
 
     (11) logical -> NOTEQUAL .
 
     STRING          reduce using rule 11 (logical -> NOTEQUAL .)
-    COLNAME         reduce using rule 11 (logical -> NOTEQUAL .)
+    COLNUMBER       reduce using rule 11 (logical -> NOTEQUAL .)
+    BRACKETED_COLNAME reduce using rule 11 (logical -> NOTEQUAL .)
+    SIMPLE_COLNAME  reduce using rule 11 (logical -> NOTEQUAL .)
     NEGATIVE_INTNUMBER reduce using rule 11 (logical -> NOTEQUAL .)
     POSITIVE_INTNUMBER reduce using rule 11 (logical -> NOTEQUAL .)
     FLOATNUMBER     reduce using rule 11 (logical -> NOTEQUAL .)
 
 
-state 72
+state 73
 
     (12) logical -> BIGGER_EQUAL .
 
     STRING          reduce using rule 12 (logical -> BIGGER_EQUAL .)
-    COLNAME         reduce using rule 12 (logical -> BIGGER_EQUAL .)
+    COLNUMBER       reduce using rule 12 (logical -> BIGGER_EQUAL .)
+    BRACKETED_COLNAME reduce using rule 12 (logical -> BIGGER_EQUAL .)
+    SIMPLE_COLNAME  reduce using rule 12 (logical -> BIGGER_EQUAL .)
     NEGATIVE_INTNUMBER reduce using rule 12 (logical -> BIGGER_EQUAL .)
     POSITIVE_INTNUMBER reduce using rule 12 (logical -> BIGGER_EQUAL .)
     FLOATNUMBER     reduce using rule 12 (logical -> BIGGER_EQUAL .)
 
 
-state 73
+state 74
 
     (13) logical -> BIGGER .
 
     STRING          reduce using rule 13 (logical -> BIGGER .)
-    COLNAME         reduce using rule 13 (logical -> BIGGER .)
+    COLNUMBER       reduce using rule 13 (logical -> BIGGER .)
+    BRACKETED_COLNAME reduce using rule 13 (logical -> BIGGER .)
+    SIMPLE_COLNAME  reduce using rule 13 (logical -> BIGGER .)
     NEGATIVE_INTNUMBER reduce using rule 13 (logical -> BIGGER .)
     POSITIVE_INTNUMBER reduce using rule 13 (logical -> BIGGER .)
     FLOATNUMBER     reduce using rule 13 (logical -> BIGGER .)
 
 
-state 74
+state 75
 
     (14) logical -> SMALLER_EQUAL .
 
     STRING          reduce using rule 14 (logical -> SMALLER_EQUAL .)
-    COLNAME         reduce using rule 14 (logical -> SMALLER_EQUAL .)
+    COLNUMBER       reduce using rule 14 (logical -> SMALLER_EQUAL .)
+    BRACKETED_COLNAME reduce using rule 14 (logical -> SMALLER_EQUAL .)
+    SIMPLE_COLNAME  reduce using rule 14 (logical -> SMALLER_EQUAL .)
     NEGATIVE_INTNUMBER reduce using rule 14 (logical -> SMALLER_EQUAL .)
     POSITIVE_INTNUMBER reduce using rule 14 (logical -> SMALLER_EQUAL .)
     FLOATNUMBER     reduce using rule 14 (logical -> SMALLER_EQUAL .)
 
 
-state 75
+state 76
 
     (15) logical -> SMALLER .
 
     STRING          reduce using rule 15 (logical -> SMALLER .)
-    COLNAME         reduce using rule 15 (logical -> SMALLER .)
+    COLNUMBER       reduce using rule 15 (logical -> SMALLER .)
+    BRACKETED_COLNAME reduce using rule 15 (logical -> SMALLER .)
+    SIMPLE_COLNAME  reduce using rule 15 (logical -> SMALLER .)
     NEGATIVE_INTNUMBER reduce using rule 15 (logical -> SMALLER .)
     POSITIVE_INTNUMBER reduce using rule 15 (logical -> SMALLER .)
     FLOATNUMBER     reduce using rule 15 (logical -> SMALLER .)
 
 
-state 76
+state 77
 
     (23) conditions -> NOT conditions .
     (19) conditions -> conditions . AND conditions
@@ -1138,76 +1246,76 @@ state 76
     LIMIT           reduce using rule 23 (conditions -> NOT conditions .)
     TAIL            reduce using rule 23 (conditions -> NOT conditions .)
     RPAREN          reduce using rule 23 (conditions -> NOT conditions .)
-    AND             shift and go to state 65
-    OR              shift and go to state 66
+    AND             shift and go to state 66
+    OR              shift and go to state 67
 
   ! AND             [ reduce using rule 23 (conditions -> NOT conditions .) ]
   ! OR              [ reduce using rule 23 (conditions -> NOT conditions .) ]
 
 
-state 77
+state 78
 
     (6) select -> SELECT distinct select_columns FROM DATASOURCE into where . order limit_or_tail SIMICOLON
-    (40) order -> . ORDER BY column way
-    (41) order -> . empty
+    (41) order -> . ORDER BY column way
+    (42) order -> . empty
     (5) empty -> .
 
-    ORDER           shift and go to state 89
+    ORDER           shift and go to state 90
     LIMIT           reduce using rule 5 (empty -> .)
     TAIL            reduce using rule 5 (empty -> .)
     SIMICOLON       reduce using rule 5 (empty -> .)
 
-    order                          shift and go to state 88
-    empty                          shift and go to state 90
-
-state 78
-
-    (38) into -> INTO DATASOURCE .
-
-    WHERE           reduce using rule 38 (into -> INTO DATASOURCE .)
-    ORDER           reduce using rule 38 (into -> INTO DATASOURCE .)
-    LIMIT           reduce using rule 38 (into -> INTO DATASOURCE .)
-    TAIL            reduce using rule 38 (into -> INTO DATASOURCE .)
-    SIMICOLON       reduce using rule 38 (into -> INTO DATASOURCE .)
-
+    order                          shift and go to state 89
+    empty                          shift and go to state 91
 
 state 79
+
+    (39) into -> INTO DATASOURCE .
+
+    WHERE           reduce using rule 39 (into -> INTO DATASOURCE .)
+    ORDER           reduce using rule 39 (into -> INTO DATASOURCE .)
+    LIMIT           reduce using rule 39 (into -> INTO DATASOURCE .)
+    TAIL            reduce using rule 39 (into -> INTO DATASOURCE .)
+    SIMICOLON       reduce using rule 39 (into -> INTO DATASOURCE .)
+
+
+state 80
 
     (7) insert -> INSERT INTO DATASOURCE icolumn VALUES insert_values SIMICOLON .
 
     $end            reduce using rule 7 (insert -> INSERT INTO DATASOURCE icolumn VALUES insert_values SIMICOLON .)
 
 
-state 80
-
-    (53) insert_values -> insert_values COMMA . insert_values
-    (53) insert_values -> . insert_values COMMA insert_values
-    (54) insert_values -> . single_values
-    (52) single_values -> . LPAREN values RPAREN
-
-    LPAREN          shift and go to state 58
-
-    insert_values                  shift and go to state 91
-    single_values                  shift and go to state 57
-
 state 81
 
-    (52) single_values -> LPAREN values . RPAREN
-    (50) values -> values . COMMA values
+    (54) insert_values -> insert_values COMMA . insert_values
+    (54) insert_values -> . insert_values COMMA insert_values
+    (55) insert_values -> . single_values
+    (53) single_values -> . LPAREN values RPAREN
 
-    RPAREN          shift and go to state 92
-    COMMA           shift and go to state 93
+    LPAREN          shift and go to state 59
 
+    insert_values                  shift and go to state 92
+    single_values                  shift and go to state 58
 
 state 82
 
-    (51) values -> value .
+    (53) single_values -> LPAREN values . RPAREN
+    (51) values -> values . COMMA values
 
-    RPAREN          reduce using rule 51 (values -> value .)
-    COMMA           reduce using rule 51 (values -> value .)
+    RPAREN          shift and go to state 93
+    COMMA           shift and go to state 94
 
 
 state 83
+
+    (52) values -> value .
+
+    RPAREN          reduce using rule 52 (values -> value .)
+    COMMA           reduce using rule 52 (values -> value .)
+
+
+state 84
 
     (19) conditions -> conditions AND conditions .
     (19) conditions -> conditions . AND conditions
@@ -1221,14 +1329,14 @@ state 83
     LIMIT           reduce using rule 19 (conditions -> conditions AND conditions .)
     TAIL            reduce using rule 19 (conditions -> conditions AND conditions .)
     RPAREN          reduce using rule 19 (conditions -> conditions AND conditions .)
-    AND             shift and go to state 65
-    OR              shift and go to state 66
+    AND             shift and go to state 66
+    OR              shift and go to state 67
 
   ! AND             [ reduce using rule 19 (conditions -> conditions AND conditions .) ]
   ! OR              [ reduce using rule 19 (conditions -> conditions AND conditions .) ]
 
 
-state 84
+state 85
 
     (20) conditions -> conditions OR conditions .
     (19) conditions -> conditions . AND conditions
@@ -1242,14 +1350,14 @@ state 84
     LIMIT           reduce using rule 20 (conditions -> conditions OR conditions .)
     TAIL            reduce using rule 20 (conditions -> conditions OR conditions .)
     RPAREN          reduce using rule 20 (conditions -> conditions OR conditions .)
-    AND             shift and go to state 65
-    OR              shift and go to state 66
+    AND             shift and go to state 66
+    OR              shift and go to state 67
 
   ! AND             [ reduce using rule 20 (conditions -> conditions OR conditions .) ]
   ! OR              [ reduce using rule 20 (conditions -> conditions OR conditions .) ]
 
 
-state 85
+state 86
 
     (18) conditions -> LPAREN conditions RPAREN .
 
@@ -1263,7 +1371,7 @@ state 85
     RPAREN          reduce using rule 18 (conditions -> LPAREN conditions RPAREN .)
 
 
-state 86
+state 87
 
     (21) conditions -> exp LIKE STRING .
 
@@ -1277,7 +1385,7 @@ state 86
     RPAREN          reduce using rule 21 (conditions -> exp LIKE STRING .)
 
 
-state 87
+state 88
 
     (22) conditions -> exp logical exp .
 
@@ -1291,210 +1399,212 @@ state 87
     RPAREN          reduce using rule 22 (conditions -> exp logical exp .)
 
 
-state 88
-
-    (6) select -> SELECT distinct select_columns FROM DATASOURCE into where order . limit_or_tail SIMICOLON
-    (45) limit_or_tail -> . LIMIT POSITIVE_INTNUMBER
-    (46) limit_or_tail -> . TAIL POSITIVE_INTNUMBER
-    (47) limit_or_tail -> . empty
-    (5) empty -> .
-
-    LIMIT           shift and go to state 95
-    TAIL            shift and go to state 96
-    SIMICOLON       reduce using rule 5 (empty -> .)
-
-    limit_or_tail                  shift and go to state 94
-    empty                          shift and go to state 97
-
 state 89
 
-    (40) order -> ORDER . BY column way
+    (6) select -> SELECT distinct select_columns FROM DATASOURCE into where order . limit_or_tail SIMICOLON
+    (46) limit_or_tail -> . LIMIT POSITIVE_INTNUMBER
+    (47) limit_or_tail -> . TAIL POSITIVE_INTNUMBER
+    (48) limit_or_tail -> . empty
+    (5) empty -> .
 
-    BY              shift and go to state 98
+    LIMIT           shift and go to state 96
+    TAIL            shift and go to state 97
+    SIMICOLON       reduce using rule 5 (empty -> .)
 
+    limit_or_tail                  shift and go to state 95
+    empty                          shift and go to state 98
 
 state 90
 
-    (41) order -> empty .
+    (41) order -> ORDER . BY column way
 
-    LIMIT           reduce using rule 41 (order -> empty .)
-    TAIL            reduce using rule 41 (order -> empty .)
-    SIMICOLON       reduce using rule 41 (order -> empty .)
+    BY              shift and go to state 99
 
 
 state 91
 
-    (53) insert_values -> insert_values COMMA insert_values .
-    (53) insert_values -> insert_values . COMMA insert_values
+    (42) order -> empty .
 
-  ! shift/reduce conflict for COMMA resolved as shift
-    SIMICOLON       reduce using rule 53 (insert_values -> insert_values COMMA insert_values .)
-    COMMA           shift and go to state 80
-
-  ! COMMA           [ reduce using rule 53 (insert_values -> insert_values COMMA insert_values .) ]
+    LIMIT           reduce using rule 42 (order -> empty .)
+    TAIL            reduce using rule 42 (order -> empty .)
+    SIMICOLON       reduce using rule 42 (order -> empty .)
 
 
 state 92
 
-    (52) single_values -> LPAREN values RPAREN .
+    (54) insert_values -> insert_values COMMA insert_values .
+    (54) insert_values -> insert_values . COMMA insert_values
 
-    SIMICOLON       reduce using rule 52 (single_values -> LPAREN values RPAREN .)
-    COMMA           reduce using rule 52 (single_values -> LPAREN values RPAREN .)
+  ! shift/reduce conflict for COMMA resolved as shift
+    SIMICOLON       reduce using rule 54 (insert_values -> insert_values COMMA insert_values .)
+    COMMA           shift and go to state 81
+
+  ! COMMA           [ reduce using rule 54 (insert_values -> insert_values COMMA insert_values .) ]
 
 
 state 93
 
-    (50) values -> values COMMA . values
-    (50) values -> . values COMMA values
-    (51) values -> . value
-    (48) value -> . STRING
-    (49) value -> . NUMBER
+    (53) single_values -> LPAREN values RPAREN .
+
+    SIMICOLON       reduce using rule 53 (single_values -> LPAREN values RPAREN .)
+    COMMA           reduce using rule 53 (single_values -> LPAREN values RPAREN .)
+
+
+state 94
+
+    (51) values -> values COMMA . values
+    (51) values -> . values COMMA values
+    (52) values -> . value
+    (49) value -> . STRING
+    (50) value -> . NUMBER
     (27) NUMBER -> . NEGATIVE_INTNUMBER
     (28) NUMBER -> . POSITIVE_INTNUMBER
     (29) NUMBER -> . FLOATNUMBER
 
-    STRING          shift and go to state 63
-    NEGATIVE_INTNUMBER shift and go to state 50
-    POSITIVE_INTNUMBER shift and go to state 51
-    FLOATNUMBER     shift and go to state 52
+    STRING          shift and go to state 64
+    NEGATIVE_INTNUMBER shift and go to state 51
+    POSITIVE_INTNUMBER shift and go to state 52
+    FLOATNUMBER     shift and go to state 53
 
-    values                         shift and go to state 99
-    value                          shift and go to state 82
-    NUMBER                         shift and go to state 64
-
-state 94
-
-    (6) select -> SELECT distinct select_columns FROM DATASOURCE into where order limit_or_tail . SIMICOLON
-
-    SIMICOLON       shift and go to state 100
-
+    values                         shift and go to state 100
+    value                          shift and go to state 83
+    NUMBER                         shift and go to state 65
 
 state 95
 
-    (45) limit_or_tail -> LIMIT . POSITIVE_INTNUMBER
+    (6) select -> SELECT distinct select_columns FROM DATASOURCE into where order limit_or_tail . SIMICOLON
 
-    POSITIVE_INTNUMBER shift and go to state 101
+    SIMICOLON       shift and go to state 101
 
 
 state 96
 
-    (46) limit_or_tail -> TAIL . POSITIVE_INTNUMBER
+    (46) limit_or_tail -> LIMIT . POSITIVE_INTNUMBER
 
     POSITIVE_INTNUMBER shift and go to state 102
 
 
 state 97
 
-    (47) limit_or_tail -> empty .
+    (47) limit_or_tail -> TAIL . POSITIVE_INTNUMBER
 
-    SIMICOLON       reduce using rule 47 (limit_or_tail -> empty .)
+    POSITIVE_INTNUMBER shift and go to state 103
 
 
 state 98
 
-    (40) order -> ORDER BY . column way
-    (32) column -> . COLNUMBER
-    (33) column -> . COLNAME
+    (48) limit_or_tail -> empty .
 
-    COLNUMBER       shift and go to state 20
-    COLNAME         shift and go to state 21
+    SIMICOLON       reduce using rule 48 (limit_or_tail -> empty .)
 
-    column                         shift and go to state 103
 
 state 99
 
-    (50) values -> values COMMA values .
-    (50) values -> values . COMMA values
+    (41) order -> ORDER BY . column way
+    (32) column -> . COLNUMBER
+    (33) column -> . BRACKETED_COLNAME
+    (34) column -> . SIMPLE_COLNAME
 
-  ! shift/reduce conflict for COMMA resolved as shift
-    RPAREN          reduce using rule 50 (values -> values COMMA values .)
-    COMMA           shift and go to state 93
+    COLNUMBER       shift and go to state 20
+    BRACKETED_COLNAME shift and go to state 21
+    SIMPLE_COLNAME  shift and go to state 22
 
-  ! COMMA           [ reduce using rule 50 (values -> values COMMA values .) ]
-
+    column                         shift and go to state 104
 
 state 100
+
+    (51) values -> values COMMA values .
+    (51) values -> values . COMMA values
+
+  ! shift/reduce conflict for COMMA resolved as shift
+    RPAREN          reduce using rule 51 (values -> values COMMA values .)
+    COMMA           shift and go to state 94
+
+  ! COMMA           [ reduce using rule 51 (values -> values COMMA values .) ]
+
+
+state 101
 
     (6) select -> SELECT distinct select_columns FROM DATASOURCE into where order limit_or_tail SIMICOLON .
 
     $end            reduce using rule 6 (select -> SELECT distinct select_columns FROM DATASOURCE into where order limit_or_tail SIMICOLON .)
 
 
-state 101
-
-    (45) limit_or_tail -> LIMIT POSITIVE_INTNUMBER .
-
-    SIMICOLON       reduce using rule 45 (limit_or_tail -> LIMIT POSITIVE_INTNUMBER .)
-
-
 state 102
 
-    (46) limit_or_tail -> TAIL POSITIVE_INTNUMBER .
+    (46) limit_or_tail -> LIMIT POSITIVE_INTNUMBER .
 
-    SIMICOLON       reduce using rule 46 (limit_or_tail -> TAIL POSITIVE_INTNUMBER .)
+    SIMICOLON       reduce using rule 46 (limit_or_tail -> LIMIT POSITIVE_INTNUMBER .)
 
 
 state 103
 
-    (40) order -> ORDER BY column . way
-    (42) way -> . ASC
-    (43) way -> . empty
-    (44) way -> . DESC
+    (47) limit_or_tail -> TAIL POSITIVE_INTNUMBER .
+
+    SIMICOLON       reduce using rule 47 (limit_or_tail -> TAIL POSITIVE_INTNUMBER .)
+
+
+state 104
+
+    (41) order -> ORDER BY column . way
+    (43) way -> . ASC
+    (44) way -> . empty
+    (45) way -> . DESC
     (5) empty -> .
 
-    ASC             shift and go to state 105
-    DESC            shift and go to state 107
+    ASC             shift and go to state 106
+    DESC            shift and go to state 108
     LIMIT           reduce using rule 5 (empty -> .)
     TAIL            reduce using rule 5 (empty -> .)
     SIMICOLON       reduce using rule 5 (empty -> .)
 
-    way                            shift and go to state 104
-    empty                          shift and go to state 106
-
-state 104
-
-    (40) order -> ORDER BY column way .
-
-    LIMIT           reduce using rule 40 (order -> ORDER BY column way .)
-    TAIL            reduce using rule 40 (order -> ORDER BY column way .)
-    SIMICOLON       reduce using rule 40 (order -> ORDER BY column way .)
-
+    way                            shift and go to state 105
+    empty                          shift and go to state 107
 
 state 105
 
-    (42) way -> ASC .
+    (41) order -> ORDER BY column way .
 
-    LIMIT           reduce using rule 42 (way -> ASC .)
-    TAIL            reduce using rule 42 (way -> ASC .)
-    SIMICOLON       reduce using rule 42 (way -> ASC .)
+    LIMIT           reduce using rule 41 (order -> ORDER BY column way .)
+    TAIL            reduce using rule 41 (order -> ORDER BY column way .)
+    SIMICOLON       reduce using rule 41 (order -> ORDER BY column way .)
 
 
 state 106
 
-    (43) way -> empty .
+    (43) way -> ASC .
 
-    LIMIT           reduce using rule 43 (way -> empty .)
-    TAIL            reduce using rule 43 (way -> empty .)
-    SIMICOLON       reduce using rule 43 (way -> empty .)
+    LIMIT           reduce using rule 43 (way -> ASC .)
+    TAIL            reduce using rule 43 (way -> ASC .)
+    SIMICOLON       reduce using rule 43 (way -> ASC .)
 
 
 state 107
 
-    (44) way -> DESC .
+    (44) way -> empty .
 
-    LIMIT           reduce using rule 44 (way -> DESC .)
-    TAIL            reduce using rule 44 (way -> DESC .)
-    SIMICOLON       reduce using rule 44 (way -> DESC .)
+    LIMIT           reduce using rule 44 (way -> empty .)
+    TAIL            reduce using rule 44 (way -> empty .)
+    SIMICOLON       reduce using rule 44 (way -> empty .)
+
+
+state 108
+
+    (45) way -> DESC .
+
+    LIMIT           reduce using rule 45 (way -> DESC .)
+    TAIL            reduce using rule 45 (way -> DESC .)
+    SIMICOLON       reduce using rule 45 (way -> DESC .)
 
 WARNING: 
 WARNING: Conflicts:
 WARNING: 
-WARNING: shift/reduce conflict for COMMA in state 37 resolved as shift
-WARNING: shift/reduce conflict for AND in state 76 resolved as shift
-WARNING: shift/reduce conflict for OR in state 76 resolved as shift
-WARNING: shift/reduce conflict for AND in state 83 resolved as shift
-WARNING: shift/reduce conflict for OR in state 83 resolved as shift
+WARNING: shift/reduce conflict for COMMA in state 38 resolved as shift
+WARNING: shift/reduce conflict for AND in state 77 resolved as shift
+WARNING: shift/reduce conflict for OR in state 77 resolved as shift
 WARNING: shift/reduce conflict for AND in state 84 resolved as shift
 WARNING: shift/reduce conflict for OR in state 84 resolved as shift
-WARNING: shift/reduce conflict for COMMA in state 91 resolved as shift
-WARNING: shift/reduce conflict for COMMA in state 99 resolved as shift
+WARNING: shift/reduce conflict for AND in state 85 resolved as shift
+WARNING: shift/reduce conflict for OR in state 85 resolved as shift
+WARNING: shift/reduce conflict for COMMA in state 92 resolved as shift
+WARNING: shift/reduce conflict for COMMA in state 100 resolved as shift

--- a/app/compiler/yacc.py
+++ b/app/compiler/yacc.py
@@ -15,6 +15,7 @@ def p_empty(p):
 
 
 def p_error(p):
+    # print(p)
     # print("Syntax error!")
     pass
 
@@ -26,14 +27,12 @@ def p_error(p):
 
 def p_select(p):
     """select : SELECT distinct select_columns FROM DATASOURCE into where order limit_or_tail SIMICOLON"""
-
     if type(p[3]) == str:
         p[3] = "'" + p[3] + "'"
 
     file_type, file_path = p[5].split(":", 1)
     if p[6]:
         load_type, load_path = p[6].split(":", 1)
-
     p[0] = (
         f"from app import etl\n"
         f"\n"
@@ -145,8 +144,8 @@ def p_conditions_not(p):
 
 
 def p_exp(p):
-    """exp : STRING
-    | COLNAME
+    """exp : column
+    | STRING
     | NUMBER"""
 
     p[0] = p[1]
@@ -182,8 +181,15 @@ def p_distinct_empty(p):
 ###########################
 def p_column(p):
     """column : COLNUMBER
-    | COLNAME"""
+    | BRACKETED_COLNAME
+    | SIMPLE_COLNAME"""
     p[0] = p[1]
+
+
+# def p_column_name(p):
+#     """column_name : BRACKETED_COLNAME
+#     | SIMPLE_COLNAME"""
+#     p[0] = p[1]
 
 
 def p_columns(p):

--- a/app/cv/threading_main.py
+++ b/app/cv/threading_main.py
@@ -12,7 +12,7 @@ def read_and_detect(path: str) -> dict[Any, Any]:
     SHARED_Q = Queue()
     res = dict[Any, Any]()
     birdsCascade = cv2.CascadeClassifier(
-        "F:\Collage\\4th year\Compilers Project\project\\app\cv\\birds1.xml"
+        "F:/Collage/4th year/Compilers Project/project/app/cv/birds1.xml"
     )
     reader = VideoReader(path=path, sentinel=SENTINEL, queue=SHARED_Q)
 

--- a/app/etl/core.py
+++ b/app/etl/core.py
@@ -24,6 +24,11 @@ def transform(data: pd.DataFrame, criteria: dict) -> pd.DataFrame:
     if criteria["FILTER"]:
         data = apply_filtering(data, criteria["FILTER"])
 
+    # ordering
+    if criteria["ORDER"]:
+        column = criteria["ORDER"][0]
+        data = data.sort_values(column, ascending=criteria["ORDER"][1] == "ASC")
+
     # columns
     if criteria["COLUMNS"] != "__all__":
         # data = data.filter(items=criteria["COLUMNS"])
@@ -37,11 +42,6 @@ def transform(data: pd.DataFrame, criteria: dict) -> pd.DataFrame:
     # distinct
     if criteria["DISTINCT"]:
         data = data.drop_duplicates()
-
-    # ordering
-    if criteria["ORDER"]:
-        column = criteria["ORDER"][0]
-        data = data.sort_values(column, ascending=criteria["ORDER"][1] == "ASC")
 
     # limit
     if criteria["LIMIT_OR_TAIL"] != None:

--- a/app/etl/helpers.py
+++ b/app/etl/helpers.py
@@ -25,27 +25,31 @@ def apply_filtering(data: pd.DataFrame, filters_expressions_tree: dict) -> pd.Da
             data = pd.merge(left, right)
         return data[~data.index.duplicated(keep="first")]
 
-    left_operand = filters_expressions_tree["left"]
+    left_operand: str = filters_expressions_tree["left"]
 
     right_operand = filters_expressions_tree["right"]
-    if (
-        type(right_operand) == str
-        and right_operand.startswith('"')
-        and right_operand.endswith('"')
-    ):
-        right_operand: str = right_operand[1:-1]
-
-    elif right_operand in data.columns:
-        right_operand: pd.DataFrame = data[right_operand]
+    # region get the value in the right operand and check if it is a int or float or string or its a column passed by name or number
+    if type(right_operand) == str:
+        if right_operand.startswith('"') and right_operand.endswith('"'):
+            right_operand: str = right_operand[1:-1]
+        elif right_operand.startswith("[") and right_operand.endswith("]"):
+            column_number = int(right_operand[1:-1])
+            right_operand: pd.DataFrame = data[data.columns[column_number]]
+        else:
+            right_operand: pd.DataFrame = data[right_operand]
+    # endregion
+    # get the column in the left operand and check if its passed by name or number
+    if left_operand.startswith("[") and left_operand.endswith("]"):
+        column_number = int(left_operand[1:-1])
+        left_operand = data[data.columns[column_number]]
+    else:
+        left_operand = data[left_operand]
 
     if operator == "like":
         return data[
-            [
-                True if re.match(right_operand, str(x)) else False
-                for x in data[left_operand]
-            ]
+            [True if re.match(right_operand, str(x)) else False for x in left_operand]
         ]
-    left_operand = data[left_operand]
+
     if operator == ">":
         return data[left_operand > right_operand]
     if operator == ">=":

--- a/main.py
+++ b/main.py
@@ -4,7 +4,11 @@ from app.etl.controllers import *
 # for testing the program wihtout ui
 if __name__ == "__main__":
 
-    query = "select * from [csv:testing_datasets/hotel_bookings.csv];"
+    query = (
+        "select arrival_date_month from [csv:testing_datasets/hotel_bookings.csv] "
+        " order by arrival_date_month asc"
+        ";"
+    )
     compilation_result = compile_to_python(query)
     if type(compilation_result) == Success:
         python_code = compilation_result.unwrap()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from app import *
 from app.etl.controllers import *
 
-# for testing the program wihtout ui
+# for testing the program without ui
 if __name__ == "__main__":
 
     query = """

--- a/main.py
+++ b/main.py
@@ -4,11 +4,11 @@ from app.etl.controllers import *
 # for testing the program wihtout ui
 if __name__ == "__main__":
 
-    query = (
-        "select arrival_date_month from [csv:testing_datasets/hotel_bookings.csv]"
-        " order by arrival_date_month asc"
-        " ;"
-    )
+    query = """
+        select arrival_date_month
+        from   [csv:testing_datasets/hotel_bookings.csv]
+        order by arrival_date_month desc; 
+        """
     compilation_result = compile_to_python(query)
     if type(compilation_result) == Success:
         python_code = compilation_result.unwrap()

--- a/main.py
+++ b/main.py
@@ -4,19 +4,16 @@ from app.etl.controllers import *
 # for testing the program without ui
 if __name__ == "__main__":
 
-    query = """
-        select *
-        from   [csv:testing_datasets/hotel_bookings.csv]
-        where  hotel == "Resort Hotel"
-        order by arrival_date_month desc
-        limit  10; 
-        """
+    query = r"""
+select hotel,[lead time],[3]
+from {csv:testing_datasets/hotel_bookings.csv} where not ([3]==[2]);"""
     compilation_result = compile_to_python(query)
     if type(compilation_result) == Success:
         python_code = compilation_result.unwrap()
         execution_result = execute_python_code(python_code)
         if type(execution_result) == Success:
             print(execution_result.unwrap())
+
         else:
             print(execution_result.unwrap_error())
 

--- a/main.py
+++ b/main.py
@@ -5,9 +5,11 @@ from app.etl.controllers import *
 if __name__ == "__main__":
 
     query = """
-        select arrival_date_month
+        select *
         from   [csv:testing_datasets/hotel_bookings.csv]
-        order by arrival_date_month desc; 
+        where  hotel == "Resort Hotel"
+        order by arrival_date_month desc
+        limit  10; 
         """
     compilation_result = compile_to_python(query)
     if type(compilation_result) == Success:

--- a/main.py
+++ b/main.py
@@ -5,9 +5,9 @@ from app.etl.controllers import *
 if __name__ == "__main__":
 
     query = (
-        "select arrival_date_month from [csv:testing_datasets/hotel_bookings.csv] "
+        "select arrival_date_month from [csv:testing_datasets/hotel_bookings.csv]"
         " order by arrival_date_month asc"
-        ";"
+        " ;"
     )
     compilation_result = compile_to_python(query)
     if type(compilation_result) == Success:

--- a/testing_datasets/hotel_bookings.csv
+++ b/testing_datasets/hotel_bookings.csv
@@ -1,5 +1,5 @@
-hotel,is_canceled,lead_time,arrival_date_year,arrival_date_month
-at Hotel,0,203,2016,December
+hotel,is canceled,lead time,arrival_date_year,arrival_date_month
+at Hotel,0,2016,2016,December
 City Hotel,1,82,2015,July
 City Hotel,0,25,2016,December
 City Hotel,0,1,2016,March


### PR DESCRIPTION
handle column names that contain spaces in select statements, add the ability to reference a column in sorting and filtering by name or by number , change the brackets of the data source from [] to {}, and handle Lexer conflicts between SIMPLE_COLNAME and the keywords.